### PR TITLE
[R4R]-feat:Replace outdated dependencies and adjust the order of guide packets

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -6,12 +6,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/urfave/cli/v2"
 
 	"github.com/Manta-Network/manta-fp-aggregator/common/cliapp"
 	"github.com/Manta-Network/manta-fp-aggregator/config"
@@ -21,8 +21,6 @@ import (
 	"github.com/Manta-Network/manta-fp-aggregator/sign"
 	"github.com/Manta-Network/manta-fp-aggregator/store"
 	"github.com/Manta-Network/manta-fp-aggregator/ws/server"
-
-	"github.com/urfave/cli/v2"
 )
 
 var (
@@ -122,7 +120,7 @@ func runNode(ctx *cli.Context, shutdown context.CancelCauseFunc) (cliapp.Lifecyc
 		privKeyPath := cfg.Node.KeyPath + "/" + DefaultPrivKeyFilename
 		pubKeyPath := cfg.Node.KeyPath + "/" + DefaultPubKeyFilename
 		if _, err := os.Stat(privKeyPath); err == nil {
-			privKeyData, err := ioutil.ReadFile(privKeyPath)
+			privKeyData, err := os.ReadFile(privKeyPath)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,6 @@ var (
 )
 
 func main() {
-
 	log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelInfo, true)))
 	app := newCli(GitCommit, GitDate)
 	if err := app.RunContext(context.Background(), os.Args); err != nil {

--- a/common/cliapp/lifecycle.go
+++ b/common/cliapp/lifecycle.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Manta-Network/manta-fp-aggregator/common/opio"
-
 	"github.com/urfave/cli/v2"
+
+	"github.com/Manta-Network/manta-fp-aggregator/common/opio"
 )
 
 type Lifecycle interface {

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -66,7 +66,7 @@ func DefaultConfiguration() *Config {
 
 func NewConfig(path string) (*Config, error) {
 	var config = new(Config)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/router/registry.go
+++ b/manager/router/registry.go
@@ -6,13 +6,12 @@ import (
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/log"
-
-	"github.com/Manta-Network/manta-fp-aggregator/manager/types"
-	"github.com/Manta-Network/manta-fp-aggregator/store"
-
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/Manta-Network/manta-fp-aggregator/manager/types"
+	"github.com/Manta-Network/manta-fp-aggregator/store"
 )
 
 type Registry struct {

--- a/manager/sign.go
+++ b/manager/sign.go
@@ -7,13 +7,13 @@ import (
 	"sync"
 	"time"
 
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	tmtypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+
 	"github.com/Manta-Network/manta-fp-aggregator/manager/types"
 	"github.com/Manta-Network/manta-fp-aggregator/node/common"
 	"github.com/Manta-Network/manta-fp-aggregator/sign"
 	"github.com/Manta-Network/manta-fp-aggregator/ws/server"
-
-	tmjson "github.com/tendermint/tendermint/libs/json"
-	tmtypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 func (m *Manager) sign(ctx types.Context, request interface{}, method types.Method) (types.SignResult, error) {

--- a/node/deal_msg.go
+++ b/node/deal_msg.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Manta-Network/manta-fp-aggregator/manager/types"
-
 	tdtypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	tmtypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+
+	"github.com/Manta-Network/manta-fp-aggregator/manager/types"
 )
 
 func (n *Node) ProcessMessage() {


### PR DESCRIPTION
1. Replace outdated dependency modules；
2. Adjust the order of the imported packages:
- Group 1: Standard library packages
- Group 2: third-party packages
- Third group: project internal package (manta-fp-aggregator related package)