### PR TITLE
Fix error message in FilterLog+ToBlock block hash mismatch

### DIFF
--- a/synchronizer/eth_synchronizer.go
+++ b/synchronizer/eth_synchronizer.go
@@ -142,7 +142,7 @@ func (syncer *EthSynchronizer) processBatch(headers []types.Header) error {
 	if logs.ToBlockHeader.Number.Cmp(lastHeader.Number) != 0 {
 		return fmt.Errorf("eth: mismatch in FilterLog#ToBlock number")
 	} else if logs.ToBlockHeader.Hash() != lastHeader.Hash() {
-		return fmt.Errorf("eth: mismatch in FitlerLog#ToBlock block hash")
+		return fmt.Errorf("eth: mismatch in FilterLog#ToBlock block hash")
 	}
 
 	if len(logs.Logs) > 0 {


### PR DESCRIPTION


This PR fixes a typo in the error message when there is a mismatch in the block hash during the synchronization process. The error message was using "FilterLog+ToBlock" with a plus sign instead of the correct format "FilterLog#ToBlock" with a hash symbol, which is consistent with other error messages in the codebase.


